### PR TITLE
<배경 품목을 구매하여 CatRoomActivity에 적용하도록 추가했습니다.>

### DIFF
--- a/app/src/main/java/com/example/testfolder/CatRoomActivity.kt
+++ b/app/src/main/java/com/example/testfolder/CatRoomActivity.kt
@@ -37,8 +37,7 @@ class CatRoomActivity : AppCompatActivity() {
         roomframe = findViewById(R.id.room_frame)
 
         // 기본 배경 설정 -> 유저가 저장한 배경이 있으면 해당 배경으로 없으면 기본 배경으로
-        roomframe.setBackgroundResource(R.drawable.room3)
-
+        SingletonKotlin.loadUserBackground(roomframe)
 
         // 사용자 코인 불러오기
         try {

--- a/app/src/main/java/com/example/testfolder/DecoActivity.kt
+++ b/app/src/main/java/com/example/testfolder/DecoActivity.kt
@@ -11,11 +11,11 @@ import androidx.recyclerview.widget.RecyclerView
 import pl.droidsonroids.gif.GifDrawable
 import pl.droidsonroids.gif.GifImageView
 
-class DecoActivity : AppCompatActivity(),ShopItemsAdapter.OnItemClickListener {
+class DecoActivity : AppCompatActivity(), ShopItemsAdapter.OnItemClickListener {
 
     private lateinit var recyclerView: RecyclerView
     private lateinit var adapter: ShopItemsAdapter
-    private lateinit var buyItemList: List<ShopItem>
+    private lateinit var buyItemList: MutableList<ShopItem>
     private lateinit var coinText: TextView
     private lateinit var frame: FrameLayout
     private lateinit var roomBtn: TextView
@@ -37,16 +37,22 @@ class DecoActivity : AppCompatActivity(),ShopItemsAdapter.OnItemClickListener {
         gifDrawable.loopCount = 0 // 무한 반복
 
         recyclerView = findViewById(R.id.buy_items_recycler_view)
-        recyclerView.layoutManager =
-            LinearLayoutManager(this, LinearLayoutManager.HORIZONTAL, false)
-
-        // db에서 불러오는 방법으로 수정해야할 것 같아요
-        buyItemList = listOf(
-            ShopItem(R.drawable.room01, "Item 1", "$0"),
-        )
+        recyclerView.layoutManager = LinearLayoutManager(this, LinearLayoutManager.HORIZONTAL, false)
+        buyItemList = mutableListOf()
         adapter = ShopItemsAdapter(buyItemList, this, this)
         recyclerView.adapter = adapter
 
+        // 현재 장착중인 배경으로 배경 설정
+        SingletonKotlin.loadUserBackground(frame)
+
+        // 사용자 코인 불러오기
+        SingletonKotlin.loadUserCoins(coinText)
+
+        // 기본 배경을 품목에 무조건 추가하도록 설정 //이거 필요함!! 없애면 안 돼유 ㅠㅠ
+        buyItemList.add(ShopItem(R.drawable.room3, "Default Room", 0))
+
+        // 사용자가 구매한 아이템 불러오기
+        SingletonKotlin.loadPurchasedItems(buyItemList, adapter)
 
         roomBtn.setOnClickListener {
             val intent = Intent(this, CatRoomActivity::class.java)
@@ -57,7 +63,8 @@ class DecoActivity : AppCompatActivity(),ShopItemsAdapter.OnItemClickListener {
             startActivity(intent)
         }
         saveBtn.setOnClickListener {
-            // db 저장
+            // 선택된 배경을 db에 저장하도록 싱글톤 구현
+            SingletonKotlin.saveUserBackground(clickedItem.name)
             showConfirmationDialog() // 팝업 띄우고 확인 누르면 룸 이동
         }
     }
@@ -80,5 +87,4 @@ class DecoActivity : AppCompatActivity(),ShopItemsAdapter.OnItemClickListener {
             }
             .show()
     }
-
 }

--- a/app/src/main/java/com/example/testfolder/ServeGame_samepicture.java
+++ b/app/src/main/java/com/example/testfolder/ServeGame_samepicture.java
@@ -40,7 +40,7 @@ public class ServeGame_samepicture extends AppCompatActivity {
     private boolean gameEnded = false;
     private long startTimeMillis;
 
-    private static final int COIN_REWARD = 30; // 코인 보상 - 게임이 어려운편이므로 보상을 30으로 높게 설정함.
+    private static final int COIN_REWARD = 10; // 코인 보상 - 어려운 편이 아니었네 ㅎ 오류 수정후 다시 보상을 10으로 조정
     private static final int MAX_CLEARS_PER_DAY = 3; // 하루 최대 클리어 횟수
 
     private FirebaseUser currentUser;

--- a/app/src/main/java/com/example/testfolder/ShopItem.kt
+++ b/app/src/main/java/com/example/testfolder/ShopItem.kt
@@ -1,3 +1,3 @@
 package com.example.testfolder
 
-data class ShopItem(val imageResource: Int, val name: String, val price: String)
+data class ShopItem(val imageResource: Int, val name: String, val price: Int)

--- a/app/src/main/java/com/example/testfolder/ShopItemsAdapter.kt
+++ b/app/src/main/java/com/example/testfolder/ShopItemsAdapter.kt
@@ -8,7 +8,11 @@ import android.widget.ImageView
 import android.widget.TextView
 import androidx.recyclerview.widget.RecyclerView
 
-class ShopItemsAdapter(private val shopItems: List<ShopItem>, private val context: Context, private val itemClickListener: OnItemClickListener) : RecyclerView.Adapter<ShopItemsAdapter.ShopItemViewHolder>() {
+class ShopItemsAdapter(
+    private val shopItems: List<ShopItem>,
+    private val context: Context,
+    private val itemClickListener: OnItemClickListener
+) : RecyclerView.Adapter<ShopItemsAdapter.ShopItemViewHolder>() { //보기 불편해서 코드 좀 내립니다. - 우석
 
     // Define the listener interface
     interface OnItemClickListener {
@@ -24,7 +28,7 @@ class ShopItemsAdapter(private val shopItems: List<ShopItem>, private val contex
         val shopItem = shopItems[position]
         holder.itemImage.setImageResource(shopItem.imageResource)
         holder.itemName.text = shopItem.name
-        holder.itemPrice.text = shopItem.price
+        holder.itemPrice.text = "${shopItem.price} coins"  // Int를 String으로 변환했습니다요
 
         // Set click listener
         holder.itemView.setOnClickListener {

--- a/app/src/main/java/com/example/testfolder/SingletonKotlin.kt
+++ b/app/src/main/java/com/example/testfolder/SingletonKotlin.kt
@@ -1,5 +1,6 @@
 package com.example.testfolder
 
+import android.widget.FrameLayout
 import android.widget.TextView
 import android.widget.Toast
 import com.google.firebase.auth.FirebaseAuth
@@ -13,17 +14,22 @@ object SingletonKotlin {
     private lateinit var database: DatabaseReference
 
     fun initialize(auth: FirebaseAuth, database: DatabaseReference) {
+        // 초기화 메서드 - 싱글톤 객체를 초기화
+        // FirebaseAuth 및 DatabaseReference 객체를 설정
         this.auth = auth
         this.database = database
         isInitialized = true
     }
 
     private fun checkInitialization() {
+        // 초기화 확인 메서드 - 싱글톤 객체가 초기화되었는지 확인
         if (!isInitialized) {
             throw IllegalStateException("SingletonKotlin is not initialized, call initialize() method first.")
         }
     }
 
+    // 사용자 코인을 불러오는 메서드
+    // 주어진 TextView에 사용자 코인 수를 표시
     fun loadUserCoins(coinText: TextView) {
         checkInitialization()
         val currentUser = auth.currentUser ?: return
@@ -41,17 +47,95 @@ object SingletonKotlin {
         })
     }
 
-    fun getAuth(): FirebaseAuth {
+    // 사용자 배경 이미지를 불러오는 메서드
+    // 주어진 FrameLayout에 사용자 배경 이미지를 설정
+    fun loadUserBackground(frame: FrameLayout) {
+        checkInitialization()
+        val currentUser = auth.currentUser ?: return
+        val userRef = database.child("users").child(currentUser.uid)
+
+        userRef.child("selectedBackground").addListenerForSingleValueEvent(object : ValueEventListener {
+            override fun onDataChange(snapshot: DataSnapshot) {
+                val selectedBackground = snapshot.getValue(String::class.java) ?: "Default Room"
+                val imageResource = getImageResourceByName(selectedBackground)
+                frame.setBackgroundResource(imageResource)
+            }
+
+            override fun onCancelled(error: DatabaseError) {
+                Toast.makeText(frame.context, "데이터베이스 오류", Toast.LENGTH_SHORT).show()
+            }
+        })
+    }
+
+    // 사용자 배경 이미지를 저장하는 메서드
+    // 사용자가 선택한 배경 이미지를 Firebase 데이터베이스에 저장
+    fun saveUserBackground(itemName: String) {
+        checkInitialization()
+        val currentUser = auth.currentUser ?: return
+        val userRef = database.child("users").child(currentUser.uid)
+        userRef.child("selectedBackground").setValue(itemName)
+    }
+
+    // 사용자가 구매한 아이템을 불러오는 메서드
+    // 사용자에게 구매한 아이템을 MutableList에 추가하고, 어댑터를 통해 RecyclerView에 표시
+    fun loadPurchasedItems(buyItemList: MutableList<ShopItem>, adapter: ShopItemsAdapter) {
+        checkInitialization()
+        val currentUser = auth.currentUser ?: return
+        val userItemsRef = database.child("user_rooms").child(currentUser.uid)
+        // 아니 기본 배경 왜 추가 안 되냐고!@#!#!@#
+        // -> 밖에서 수동적으로 추가하는 방식으로 노선 변경
+        // // //buyItemList.add(ShopItem(R.drawable.room3, "Default Room", 0)) // 이 녀석을 직접 페이지에 코드 추가하자
+        userItemsRef.addListenerForSingleValueEvent(object : ValueEventListener {
+            override fun onDataChange(snapshot: DataSnapshot) {
+                // 기본 배경을 제외한 나머지 아이템들을 추가
+                for (itemSnapshot in snapshot.children) {
+                    val itemName = itemSnapshot.key
+                    val itemPrice = itemSnapshot.child("price").getValue(Int::class.java) ?: 0
+                    val purchased = itemSnapshot.child("purchased").getValue(Boolean::class.java) ?: false
+
+                    if (purchased) {
+                        val imageResource = getImageResourceByName(itemName)
+                        val shopItem = ShopItem(imageResource, itemName!!, itemPrice)
+                        buyItemList.add(shopItem)
+                    }
+                }
+                adapter.notifyDataSetChanged()
+            }
+
+            override fun onCancelled(error: DatabaseError) {
+                // 에러 처리 냅둠
+            }
+        })
+    }
+
+    // 아이템 이름에 따라 이미지 리소스를 반환하는 함수
+    // db에 저장된 아이템 이름에 해당하는 이미지를 반환
+    private fun getImageResourceByName(itemName: String?): Int {
+        return when (itemName) {
+            "Room 1" -> R.drawable.room01
+            "Room 2" -> R.drawable.room02
+            "Room 3" -> R.drawable.room03
+            "Room 4" -> R.drawable.room04
+            "Room 5" -> R.drawable.room05
+            "Room 6" -> R.drawable.room06
+            "Room 7" -> R.drawable.room07
+            "Room 8" -> R.drawable.room08
+            "Default Room" -> R.drawable.room3
+            else -> R.drawable.room3 // 기본 이미지 설정
+        }
+    }
+
+    fun getAuth(): FirebaseAuth { //파이어베이스 객체 반환
         checkInitialization()
         return auth
     }
 
-    fun getDatabase(): DatabaseReference {
+    fun getDatabase(): DatabaseReference { //데이터베이스레퍼런스 객체 반환
         checkInitialization()
         return database
     }
 
-    fun getCurrentUser(): FirebaseUser? {
+    fun getCurrentUser(): FirebaseUser? { //현재 로그인된 유저 정보 객체 반환
         checkInitialization()
         return auth.currentUser
     }

--- a/app/src/main/res/layout/activity_deco.xml
+++ b/app/src/main/res/layout/activity_deco.xml
@@ -127,8 +127,8 @@
         android:orientation="horizontal"
         android:background="#D6CDB6"
         app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent">
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent">
 
         <TextView
             android:id="@+id/room_btn_deco"


### PR DESCRIPTION
주요 변경 사항들!  **확인후 PR 승인 바랍니다.**

1. SingletonKotlin.kt 변경사항 : loadUserBackground 매서드에 FrameLayout 타입의 매개변수를 받아와 사용자 배경 이미지를 해당 이미지로 설정할 수 있도록 하였습니다. -> db의 users 태그라인에 selectedBackground라는 태그를 추가하여 현재 배경을 표시해줄 수 있습니다. 사용자 배경 이미지를 저장하는 saveUserBackground 매서드를 추가했습니다. 사용자가 구매한 아이템을 deco 페이지에 불러오도록 loadPurchasedItems 매서드를 추가하였습니다. 아이템 이름마다 해당 이미지 리소스를 가져올 수 있도록 하드 코딩으로 getImageResourceByName을 추가했습니다.

2. CatRoomActivity 변경사항 : 배경 설정을 loadUserBackground 매서드를 통해 roomfram을 가져올 수 있도록 하였습니다.

3. DecoActivity 변경사항: buyitem리스트에 일단 기본 배경을 맨앞에 추가하고, 나머지를 loadPurchasedItems를 통해 해당 리스트 뒤에 구만해 배경 품목을 추가하여 표시하도록 하였습니다.

4. ShopActivity의 품목을 Room n으로 변경하고 가격을 int형으로 변경하였습니다. 상점 페이지의 배경도 현재 장착중인 배경으로 설정하도록 loadUserBackground를 적용하였습니다. 별 누나가 만들어 놓은 구매확인 매서드를 활용하여, DB에 해당 품목이 저장되어 있는지를 찾는 것을 통해 구매했는지를 먼저 확인한 후에 이에 따라 다르게 처리할 수 있도록 하였습니다.

etc : ServeGame_samepicture의 보상을 다시 10으로 조정하였습니다.