### PR TITLE
문제 품질 개선, 순차적 호출(삭제, 저장 순서), 캘린더 코드 병합, 주관식 문제 생성 가능,  더블클릭 방지

### DIFF
--- a/app/src/main/java/com/example/testfolder/Diary_write_UI.kt
+++ b/app/src/main/java/com/example/testfolder/Diary_write_UI.kt
@@ -16,25 +16,32 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.constraintlayout.widget.ConstraintLayout
 import com.example.testfolder.utils.LoadingAnimation
 import com.example.testfolder.utils.OpenAI
-import com.google.firebase.database.DatabaseReference
 import com.google.firebase.database.FirebaseDatabase
 import com.google.firebase.auth.FirebaseAuth
-import java.text.SimpleDateFormat
 import java.util.*
 import com.example.testfolder.utils.PreprocessTexts
 import com.example.testfolder.viewmodels.ApiKeyViewModel
 import androidx.lifecycle.ViewModelProvider
+import com.example.testfolder.viewmodels.DiaryWriteViewModel
+import com.example.testfolder.viewmodels.FirebaseViewModel
 
 class Diary_write_UI : AppCompatActivity() {
-    private lateinit var databaseReference: DatabaseReference
-    private lateinit var auth: FirebaseAuth
-    private lateinit var database: FirebaseDatabase
+    val database: FirebaseDatabase = FirebaseDatabase.getInstance()
+    val auth: FirebaseAuth = FirebaseAuth.getInstance() // FirebaseAuth 객체 초기화
+    val currentUser = auth.currentUser
+    val uid = currentUser?.uid // 현재 로그인된 사용자의 UID 가져오기
+    private val interval: Long = 1000
+    private var lastClickTime: Long = 0
+    private var numOfQuestions: Int = 0
+    private var numOfTokens: Int = 0
+    private lateinit var diaryContent: String
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
         val apiKeyViewModel = ViewModelProvider(this).get(ApiKeyViewModel::class.java)
-        Log.d("Open AI", "Open AI Class is being created")
-        val myOpenAI = OpenAI(this, apiKeyViewModel)
+        val firebaseViewModel = ViewModelProvider(this).get(FirebaseViewModel::class.java)
+        val diaryWriteViewModel = ViewModelProvider(this).get(DiaryWriteViewModel::class.java)
 
         setContentView(R.layout.activity_write_diary)
 
@@ -48,50 +55,91 @@ class Diary_write_UI : AppCompatActivity() {
         val loadingBackgroundLayout = findViewById<ConstraintLayout>(R.id.loading_background_layout)
         val loadingImage = findViewById<ImageView>(R.id.loading_image)
         val loadingText = findViewById<TextView>(R.id.loading_text)
-        var calendarBtn = findViewById<ImageButton>(R.id.calBtn)
-        var calendar = Calendar.getInstance()
-        var year = calendar.get(Calendar.YEAR)
-        var month = calendar.get(Calendar.MONTH)
-        var day = calendar.get(Calendar.DAY_OF_MONTH)
+        val calendarBtn = findViewById<ImageButton>(R.id.calBtn)
+        val calendar = Calendar.getInstance()
+        val year = calendar.get(Calendar.YEAR)
+        val month = calendar.get(Calendar.MONTH)
+        val day = calendar.get(Calendar.DAY_OF_MONTH)
 
-        // Firebase 데이터베이스 루트 참조 가져오기
-        databaseReference = FirebaseDatabase.getInstance().reference.child("diaries")
-        auth = FirebaseAuth.getInstance() // FirebaseAuth 객체 초기화
-        database = FirebaseDatabase.getInstance()
+        Log.d("Open AI", "Open AI Class is being created")
+        val myOpenAI = OpenAI(this, apiKeyViewModel, firebaseViewModel)
 
+//        // UI 상 date가 바뀔 때마다 동작하는 함수
+//        diaryWriteViewModel.liveDataDate.observe(this) {
+//            myOpenAI.updateDate(dateTextView.text.toString())
+//        }
 
-        // 현재 날짜를 가져오기
-        val currentDate = getCurrentDate()
-        // 날짜를 TextView에 설정
-        dateTextView.text = currentDate
+        // Once a DB table whose date is the same as selected date is delete
+        // Save new data from ChatGPT
+        firebaseViewModel.OX_table_deleted.observe(this) {
+            myOpenAI.save_OX_data()
+        }
+
+        // Once a DB table whose date is the same as selected date is delete
+        // Save new data from ChatGPT
+        firebaseViewModel.MCQ_table_deleted.observe(this) {
+            myOpenAI.save_MCQ_data()
+        }
+
+        // Once a DB table whose date is the same as selected date is delete
+        // Save new data from ChatGPT
+        firebaseViewModel.blank_table_deleted.observe(this) {
+            myOpenAI.save_blank_quiz_data()
+        }
+
+        // Save 버튼 클릭 시 날짜 표시 및 일기 내용 저장
+        saveButton.setOnClickListener {
+        // Prevent double click the button
+        val currentTime = System.currentTimeMillis()
+            if (currentTime - lastClickTime >= interval) {
+                lastClickTime = currentTime
+                Log.d("SAVE_BUTTON", "Diary save button clicked.")
+                // Update class variable with the current diary content
+                this.diaryContent = diaryEditText.text.toString().trim()
+                this.numOfTokens = PreprocessTexts.getNumOfTokens(diaryContent)
+                this.numOfQuestions = numOfTokens/5
+                // If the diary is too short, don't run
+                if (numOfQuestions < 1){
+                    errorTextView.text = "The diary is too short"
+                    errorTextView.visibility = TextView.VISIBLE
+                }
+                // Run only if the diary is long enough
+                else {
+                    errorTextView.visibility = TextView.INVISIBLE
+                    diaryWriteViewModel.onButtonClick()
+                }
+            }
+        }
 
         // calendar Button 클릭 시
         calendarBtn.setOnClickListener {
             val datePickerDialog = DatePickerDialog(this, { _, year, month, day
                 ->
-                dateTextView.text =
-                    year.toString() + "/" + (month + 1).toString() + "/" + day.toString()
+                // 날짜를 TextView에 설정
+                dateTextView.text = String.format("%s/%s/%s", year, month+1, day)
             }, year, month, day)
             datePickerDialog.show()
         }
 
-        // Save 버튼 클릭 시 날짜 표시 및 일기 내용 저장
-        saveButton.setOnClickListener {
+        diaryWriteViewModel.buttonClickEvent.observe(this){
             val loadingAnimation = LoadingAnimation(this,
                 loadingBackgroundLayout, loadingImage, loadingText)
 
-            // 일기 내용을 Firebase 데이터베이스에 업로드
-            val diaryContent = diaryEditText.text.toString().trim()
-            // 일기 내용을 가져온 후, EditText 내용 Clear
+//            ViewModel에 있는 date 값을 담고있는 LiveData를 update
+//            diaryWriteViewModel.setDate(dateTextView.text.toString())
+
+            // EditText 내용 Clear
             diaryEditText.text.clear()
-            // 현재 로그인된 사용자의 UID 가져오기
-            val currentUser = auth.currentUser
-            val userId = currentUser?.uid
+            Log.d("Date", dateTextView.text.toString())
+            // OpenAI 인스턴스의 date도 함께 update
+            myOpenAI.updateDate(dateTextView.text.toString())
+
+            // 일기 내용을 Firebase 데이터베이스에 업로드
             // 사용자별로 데이터 저장하기
-            userId?.let {
-                val userDiaryRef = databaseReference.child(it) // 사용자별 레퍼런스 생성
+            uid?.let {
+                val userDiaryRef = database.reference.child("diaries").child(it) // 사용자별 레퍼런스 생성
                 val diaryEntryMap = mapOf(
-                    "date" to currentDate,
+                    "date" to dateTextView.text,
                     "content" to diaryContent
                 )
                 val dbTask = userDiaryRef.push().setValue(diaryEntryMap) // 사용자별 위치에 일기 저장
@@ -101,29 +149,20 @@ class Diary_write_UI : AppCompatActivity() {
             }
 
             // TEST
-            if (userId != null) {
-                val numOfTokens = PreprocessTexts.getNumOfTokens(diaryContent)
-                val numOfQuestions = numOfTokens/5
-                if (numOfQuestions < 1){
-                    errorTextView.text = "The diary is too short"
-                    errorTextView.visibility = TextView.VISIBLE
-                }
-                else {
+            if (uid != null) {
 //                    loadingAnimation.showLoading()
 
-                    errorTextView.text = ""
-                    errorTextView.visibility = TextView.INVISIBLE
+                errorTextView.visibility = TextView.INVISIBLE
 
-                    // Observe the LiveData
-                    apiKeyViewModel.apiKey.observe(this) {
-                        myOpenAI.generate_OX_quiz_and_save(
-                            loadingAnimation,
-                            diaryContent,
-                            numOfQuestions,
-                            dateTextView.text.toString())
-                    }
-                    myOpenAI.fetchApiKey()
+                // Observe the LiveData
+                apiKeyViewModel.apiKey.observe(this) {
+                    myOpenAI.generate_OX_quiz_and_save(
+                        loadingAnimation,
+                        this.diaryContent,
+                        this.numOfQuestions)
                 }
+                myOpenAI.fetchApiKey()
+
 
             } else {
                 Toast.makeText(this, "User not authenticated", Toast.LENGTH_SHORT).show()
@@ -153,10 +192,10 @@ class Diary_write_UI : AppCompatActivity() {
         }
     }
 
-    // 현재 날짜를 가져오는 함수
-    private fun getCurrentDate(): String {
-        val calendar = Calendar.getInstance()
-        val dateFormat = SimpleDateFormat("yyyy/MM/dd", Locale.getDefault())
-        return dateFormat.format(calendar.time)
-    }
+//    // 현재 날짜를 가져오는 함수
+//    private fun getCurrentDate(): String {
+//        val calendar = Calendar.getInstance()
+//        val dateFormat = SimpleDateFormat("yyyy/MM/dd", Locale.getDefault())
+//        return dateFormat.format(calendar.time)
+//    }
 }

--- a/app/src/main/java/com/example/testfolder/utils/OpenAI.kt
+++ b/app/src/main/java/com/example/testfolder/utils/OpenAI.kt
@@ -1,12 +1,16 @@
 package com.example.testfolder.utils
 
-import android.content.Context
 import android.util.Log
+import androidx.lifecycle.LifecycleOwner
 import com.example.testfolder.viewmodels.ApiKeyViewModel
+import com.example.testfolder.viewmodels.FirebaseViewModel
 import com.google.android.gms.tasks.Task
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.database.FirebaseDatabase
 import com.google.firebase.functions.FirebaseFunctions
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 import okhttp3.Call
 import okhttp3.Callback
 import okhttp3.MediaType
@@ -20,29 +24,44 @@ import org.json.JSONArray
 import org.json.JSONException
 import org.json.JSONObject
 
-class OpenAI(context: Context, viewModel: ApiKeyViewModel) {
+class OpenAI(lifecycleOwner: LifecycleOwner, apiKeyViewModel: ApiKeyViewModel, firebaseViewModel: FirebaseViewModel) {
     companion object {
-        const val PROB_TYPE_MCQ = "MCQ"
-        const val PROB_TYPE_OX  = "OX"
+        const val PROB_TYPE_OX  = 0
+        const val PROB_TYPE_MCQ = 1
+        const val PROB_TYPE_BLANK  = 2
     }
     private lateinit var apiKey: String
     private lateinit var loadingAnimation: LoadingAnimation
-    private var context: Context
-    private var viewModel: ApiKeyViewModel
+    private lateinit var date: String
+    private lateinit var response_gpt_OX: String
+    private lateinit var response_gpt_MCQ: String
+    private lateinit var response_gpt_blank: String
+    private var lifecycleOwner: LifecycleOwner
+    private var apiKeyViewModel: ApiKeyViewModel
+    private var firebaseViewModel: FirebaseViewModel
     val model = "gpt-3.5-turbo-0125"
+    val database: FirebaseDatabase = FirebaseDatabase.getInstance()
+    val auth: FirebaseAuth = FirebaseAuth.getInstance() // FirebaseAuth 객체 초기화
+    val currentUser = auth.currentUser
+    val uid = currentUser?.uid
 
     init {
-        this.context = context
-        this.viewModel = viewModel
+        this.lifecycleOwner = lifecycleOwner
+        this.apiKeyViewModel = apiKeyViewModel
+        this.firebaseViewModel = firebaseViewModel
+    }
+
+    fun updateDate(date: String) {
+        this.date = date
     }
 
     fun fetchApiKey() {
         getOpenaiApiKey().addOnCompleteListener { task ->
             if (task.isSuccessful) {
                 this.apiKey = task.result
-                viewModel.setApiKey(this.apiKey)
+                apiKeyViewModel.setApiKey(this.apiKey)
                 // Use the API key
-//                Log.d("API_KEY", apiKey)
+                Log.d("API_KEY", "Received API Key successfully")
             } else {
                 Log.e("API_KEY_ERROR", "Error fetching API key", task.exception)
             }
@@ -69,12 +88,14 @@ class OpenAI(context: Context, viewModel: ApiKeyViewModel) {
             }
     }
 
-    fun generate_OX_quiz_and_save(loadingAnimation: LoadingAnimation, diary: String, numOfQuestions: Int, date: String) {
+    fun generate_OX_quiz_and_save(loadingAnimation: LoadingAnimation, diary: String, numOfQuestions: Int) {
         this.loadingAnimation = loadingAnimation
-        var prompt = get_prompt_OX_quiz(diary, numOfQuestions)
-        get_response_and_save(prompt, date, PROB_TYPE_OX)
-        prompt = get_prompt_MCQ_quiz(diary, numOfQuestions)
-        get_response_and_save(prompt, date, PROB_TYPE_MCQ)
+        val prompt_OX = get_prompt_OX_quiz(diary, numOfQuestions)
+        val prompt_MCQ = get_prompt_MCQ_quiz(diary, numOfQuestions)
+        val prompt_blank = get_prompt_blank_quiz(diary, numOfQuestions/2)
+        get_response_and_save(prompt_OX, PROB_TYPE_OX)
+        get_response_and_save(prompt_MCQ, PROB_TYPE_MCQ)
+        get_response_and_save(prompt_blank, PROB_TYPE_BLANK)
     }
 
     private fun get_prompt_OX_quiz(diary: String, numOfQuestions: Int): String {
@@ -96,85 +117,125 @@ class OpenAI(context: Context, viewModel: ApiKeyViewModel) {
         return prompt_OX
     }
 
-    private fun get_response_and_save(prompt: String, date: String, probType: String) {
-        // Using coroutines to run this block in backgroud thread
-//        CoroutineScope(Dispatchers.IO).launch {
-        val mediaType: MediaType = "application/json; charset=utf-8".toMediaType()
-        val okHttpClient = OkHttpClient()
-        val messages = JSONArray()
-        val systemMsg = JSONObject()
-        val userMsg = JSONObject()
-        val json = JSONObject()
-        // system message that is gonna be contained in the final json object
-        systemMsg.put("role", "system")
-        systemMsg.put("content", "You are a helpful assistant.")
-        // user message that is gonna be contained in the final json object
-        userMsg.put("role", "user")
-        userMsg.put("content", prompt)
-        // Create value of the key messages that is gonna be contained in the final json object
-        messages.put(systemMsg)
-        messages.put(userMsg)
-        // Create a final json object to send through API call
-        json.put("model", model)
-        json.put("messages", messages)
-        val requestBody: RequestBody = json.toString().toRequestBody(mediaType)
-        val request: Request =
-            Request.Builder()
-                .url("https://api.openai.com/v1/chat/completions")
-                .addHeader("Authorization", "Bearer $apiKey")
-                .post(requestBody)
-                .build()
-
-        okHttpClient.newCall(request).enqueue(object : Callback {
-            override fun onResponse(call: Call, response: Response) {
-                if (response.isSuccessful) {
-                    try {
-                        val jsonObject = JSONObject(response.body?.string() ?: "")
-                        val jsonArray = jsonObject.getJSONArray("choices")
-                        // 아래 result 받아오는 경로가 좀 수정되었다.
-                        val result = jsonArray.getJSONObject(0).getJSONObject("message").getString("content").trim()
-                        Log.i("GPT", "response: "+result.trim())
-                        // Save the response to DB
-                        when (probType) {
-                            PROB_TYPE_OX -> {
-                                save_OX_data(result, date)
-                            }
-                            PROB_TYPE_MCQ -> {
-                                save_MCQ_data(result, date)
-                            }
-                            else -> {
-                                throw Exception("Wrong problem type specified")
-                            }
-                        }
-                    } catch (e: JSONException) {
-                        e.printStackTrace()
-                    }
-                } else {
-                    Log.i("GPT", "Failed to load response due to ${response.body?.string()}")
-                }
-            }
-
-            override fun onFailure(call: Call, e: java.io.IOException) {
-                Log.i("GPT", "onFailure: ")
-            }
-        })
-//        }
+    private fun get_prompt_blank_quiz(diary: String, numOfQuestions: Int): String {
+        val prompt_OX = "Generate $numOfQuestions blank quiz based on the following diary." +
+                "\nDiary: $diary" +
+                "\nExample answer: " +
+                "{\"question\": \"I had <blank> for lunch.\", " +
+                "\"answer\": \"pizza\"}" +
+                "Don't generate time related quiz. Each question must have only one <blank> which has to match one word." +
+                "Each answer should be separated by \"\\n\", and don't add any introduction to your response."
+        return prompt_OX
     }
-    private fun save_OX_data(response: String, date: String) {
-        val database: FirebaseDatabase = FirebaseDatabase.getInstance()
-        val auth: FirebaseAuth = FirebaseAuth.getInstance() // FirebaseAuth 객체 초기화
-        val currentUser = auth.currentUser
-        val uid = currentUser?.uid
-        if(uid != null) {
-            var ref = database.reference.child("ox_quiz").child(uid).child(date)
-            var dbTask = ref.removeValue()
+
+    private fun get_response_and_save(prompt: String, probType: Int) {
+        // Using coroutines to run this block in backgroud thread
+        CoroutineScope(Dispatchers.Main).launch {
+            val mediaType: MediaType = "application/json; charset=utf-8".toMediaType()
+            val okHttpClient = OkHttpClient()
+            val messages = JSONArray()
+            val systemMsg = JSONObject()
+            val userMsg = JSONObject()
+            val json = JSONObject()
+            // system message that is gonna be contained in the final json object
+            systemMsg.put("role", "system")
+            systemMsg.put("content", "You are Dictionary bot. Your job is to generate quiz into multiple dictionaries without any bullets")
+            // user message that is gonna be contained in the final json object
+            userMsg.put("role", "user")
+            userMsg.put("content", prompt)
+            // Create value of the key messages that is gonna be contained in the final json object
+            messages.put(systemMsg)
+            messages.put(userMsg)
+            // Create a final json object to send through API call
+            json.put("model", model)
+            json.put("messages", messages)
+            json.put("temperature", 0)
+            val requestBody: RequestBody = json.toString().toRequestBody(mediaType)
+            val request: Request =
+                Request.Builder()
+                    .url("https://api.openai.com/v1/chat/completions")
+                    .addHeader("Authorization", "Bearer $apiKey")
+                    .post(requestBody)
+                    .build()
+
+            okHttpClient.newCall(request).enqueue(object : Callback {
+                override fun onResponse(call: Call, response: Response) {
+                    if (response.isSuccessful) {
+                        try {
+                            Log.d("GPT-CALL", "Response received.")
+                            val jsonObject = JSONObject(response.body?.string() ?: "")
+                            val jsonArray = jsonObject.getJSONArray("choices")
+                            // 아래 result 받아오는 경로가 좀 수정되었다.
+                            val result = jsonArray.getJSONObject(0).getJSONObject("message")
+                                .getString("content").trim()
+                            // Save the response to DB
+                            when (probType) {
+                                PROB_TYPE_OX -> {
+                                    // update response
+                                    response_gpt_OX = result
+                                    // Delete existing diary for the day first
+                                    delete_data("ox_quiz", PROB_TYPE_OX)
+                                }
+
+                                PROB_TYPE_MCQ -> {
+                                    // update response
+                                    response_gpt_MCQ = result
+                                    // Delete existing diary for the day first
+                                    delete_data("mcq_quiz", PROB_TYPE_MCQ)
+                                }
+
+                                PROB_TYPE_BLANK -> {
+                                    // update response
+                                    response_gpt_blank = result
+                                    // Delete existing diary for the day first
+                                    delete_data("blank_quiz", PROB_TYPE_BLANK)
+                                }
+
+                                else -> {
+                                    throw Exception("Wrong problem type specified")
+                                }
+                            }
+                        } catch (e: JSONException) {
+                            e.printStackTrace()
+                        }
+                    } else {
+                        Log.i("GPT", "Failed to load response due to ${response.body?.string()}")
+                    }
+                }
+
+                override fun onFailure(call: Call, e: java.io.IOException) {
+                    Log.i("GPT", "onFailure: ")
+                }
+            })
+        }
+    }
+
+    private fun delete_data(tableName: String, probType: Int) {
+        if (uid != null) {
+            val ref = database.reference.child(tableName).child(uid).child(this.date)
+            val dbTask = ref.removeValue()
             dbTask.addOnSuccessListener {
                 Log.i("DB", "Data Deleted successfully.")
-            }
+                when (probType) {
+                    PROB_TYPE_OX -> firebaseViewModel.set_OX_table_deleted(true)
+                    PROB_TYPE_MCQ -> firebaseViewModel.set_MCQ_table_deleted(true)
+                    PROB_TYPE_BLANK -> firebaseViewModel.set_blank_table_deleted(true)
+                    else -> throw Exception("Got a wrong problem type to trigger the LiveData")
+                }
 
-            val quizList = response.split("\n")
+            }
+        } else {
+            Log.i("DB", "UID not found.")
+        }
+    }
+
+    fun save_OX_data() {
+        if (uid != null) {
+            Log.i("GPT-OX", "response: " + this.response_gpt_OX)
+            val quizList = this.response_gpt_OX.split("\n")
             quizList.forEachIndexed { index, quiz ->
-                ref = database.reference.child("ox_quiz").child(uid).child(date).child(index.toString())
+                val ref = database.reference.child("ox_quiz").child(uid).child(date)
+                    .child(index.toString())
                 val jsonObject = JSONObject(quiz)
                 val question = jsonObject.getString("question")
                 val answer = jsonObject.getString("answer")
@@ -182,7 +243,7 @@ class OpenAI(context: Context, viewModel: ApiKeyViewModel) {
                     "question" to question,
                     "answer" to answer
                 )
-                dbTask = ref.setValue(recordMap)
+                val dbTask = ref.setValue(recordMap)
                 dbTask.addOnSuccessListener {
 //                    this.loadingAnimation.hideLoading()
                     Log.i("DB", "Data saved successfully")
@@ -192,21 +253,13 @@ class OpenAI(context: Context, viewModel: ApiKeyViewModel) {
         }
     }
 
-    private fun save_MCQ_data(response: String, date: String) {
-        val database: FirebaseDatabase = FirebaseDatabase.getInstance()
-        val auth: FirebaseAuth = FirebaseAuth.getInstance() // FirebaseAuth 객체 초기화
-        val currentUser = auth.currentUser
-        val uid = currentUser?.uid
-        if(uid != null) {
-            var ref = database.reference.child("mcq_quiz").child(uid).child(date)
-            var dbTask = ref.removeValue()
-            dbTask.addOnSuccessListener {
-                Log.i("DB", "Data Deleted successfully.")
-            }
-
-            val quizList = response.split("\n")
+    fun save_MCQ_data() {
+        if (uid != null) {
+            Log.i("GPT-MCQ", "response: " + this.response_gpt_MCQ)
+            val quizList = this.response_gpt_MCQ.split("\n")
             quizList.forEachIndexed { index, quiz ->
-                ref = database.reference.child("mcq_quiz").child(uid).child(date).child(index.toString())
+                val ref = database.reference.child("mcq_quiz").child(uid).child(date)
+                    .child(index.toString())
                 val jsonObject = JSONObject(quiz)
                 val question = jsonObject.getString("question")
                 val choices = jsonObject.getString("choices")
@@ -216,7 +269,7 @@ class OpenAI(context: Context, viewModel: ApiKeyViewModel) {
                     "choices" to choices,
                     "answer" to answer
                 )
-                dbTask = ref.setValue(recordMap)
+                val dbTask = ref.setValue(recordMap)
                 dbTask.addOnSuccessListener {
 //                    this.loadingAnimation.hideLoading()
                     Log.i("DB", "Data saved successfully")
@@ -225,4 +278,29 @@ class OpenAI(context: Context, viewModel: ApiKeyViewModel) {
             }
         }
     }
+
+    fun save_blank_quiz_data() {
+        if(uid != null) {
+            Log.i("GPT-BLANK", "response: " + this.response_gpt_blank)
+            val quizList = this.response_gpt_blank.split("\n")
+            quizList.forEachIndexed { index, quiz ->
+                val ref = database.reference.child("blank_quiz").child(uid).child(date)
+                    .child(index.toString())
+                val jsonObject = JSONObject(quiz)
+                val question = jsonObject.getString("question")
+                val answer = jsonObject.getString("answer")
+                val recordMap = mapOf(
+                    "question" to question,
+                    "answer" to answer
+                )
+                val dbTask = ref.setValue(recordMap)
+                dbTask.addOnSuccessListener {
+//                    this.loadingAnimation.hideLoading()
+                    Log.i("DB", "Data saved successfully")
+//                    Toast.makeText(this.context, "Data saved successfully", Toast.LENGTH_SHORT).show()
+                }
+            }
+        }
+    }
+
 }

--- a/app/src/main/java/com/example/testfolder/viewmodels/DiaryWriteViewModel.kt
+++ b/app/src/main/java/com/example/testfolder/viewmodels/DiaryWriteViewModel.kt
@@ -1,0 +1,21 @@
+package com.example.testfolder.viewmodels
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+
+class DiaryWriteViewModel : ViewModel() {
+    private val _liveDataDate = MutableLiveData<String>()
+    val liveDataDate: LiveData<String> get() = _liveDataDate
+    private val _buttonClickEvent = MutableLiveData<Unit>()
+    val buttonClickEvent: LiveData<Unit> get() = _buttonClickEvent
+
+    fun setDate(date: String) {
+        // setValue()를 사용하여 값 셋팅
+        _liveDataDate.value = date
+    }
+
+    fun onButtonClick() {
+        _buttonClickEvent.value = Unit
+    }
+}

--- a/app/src/main/java/com/example/testfolder/viewmodels/FirebaseViewModel.kt
+++ b/app/src/main/java/com/example/testfolder/viewmodels/FirebaseViewModel.kt
@@ -1,0 +1,29 @@
+package com.example.testfolder.viewmodels
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+
+class FirebaseViewModel : ViewModel() {
+    private val _OX_table_deleted = MutableLiveData<Boolean>()
+    private val _MCQ_table_deleted = MutableLiveData<Boolean>()
+    private val _blank_table_deleted = MutableLiveData<Boolean>()
+    val OX_table_deleted: LiveData<Boolean> get() = _OX_table_deleted
+    val MCQ_table_deleted: LiveData<Boolean> get() = _MCQ_table_deleted
+    val blank_table_deleted: LiveData<Boolean> get() = _blank_table_deleted
+
+    fun set_OX_table_deleted(value: Boolean) {
+        // setValue()를 사용하여 값 셋팅
+        _OX_table_deleted.postValue(value)
+    }
+
+    fun set_MCQ_table_deleted(value: Boolean) {
+        // setValue()를 사용하여 값 셋팅
+        _MCQ_table_deleted.postValue(value)
+    }
+
+    fun set_blank_table_deleted(value: Boolean) {
+        // setValue()를 사용하여 값 셋팅
+        _blank_table_deleted.postValue(value)
+    }
+}


### PR DESCRIPTION
문제 품질 개선
- User message, System message 모두 수정

순차적 호출
- Firebase의 기존 데이터가 삭제되기 전에 저장되는 이슈 해결

캘린터 코드 병합
- 별 누나가 이전에 캘린더 코드를 추가하며 발생한 Diary_write_UI.kt에서의 충돌 사항 해결

주관식 문제 생성 가능
- 주관식 문제 생성하여 DB에 저장하기까지 기능 구현 완료
- 실제 게임 시에 답변 체크하는 기능 구현 필요

더블클릭 방지
- 일기 화면에서 SAVE 버튼 누를 시, 여러번 눌러서 호출이 여러번 되던 오류 해결
